### PR TITLE
Add tests that leverage the powerquery-parser project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -384,6 +384,12 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -815,6 +821,15 @@
         "base64-js": "^1.2.3",
         "xmlbuilder": "^9.0.7",
         "xmldom": "0.1.x"
+      }
+    },
+    "powerquery-parser": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/powerquery-parser/-/powerquery-parser-0.0.10.tgz",
+      "integrity": "sha512-+UQ+Wtx7HCTChrdpdE2gW+vnBpl0KCBMKCcKdefeWkCcnYQcR98kMytBrSEtcERC7T1UcsecNKRx+ZDKcvHldw==",
+      "dev": true,
+      "requires": {
+        "grapheme-splitter": "^1.0.4"
       }
     },
     "pump": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "mocha": "latest",
     "mocha-multi-reporters": "latest",
     "plist": "latest",
+    "powerquery-parser": "latest",
     "typescript": "latest",
     "vscode-textmate": "^3.3.3"
   }

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,6 +1,7 @@
 import path = require('path');
 import vsctm = require('vscode-textmate');
-import { expect } from "chai";
+import { Lexer, Token } from 'powerquery-parser';
+import { expect, should } from "chai";
 import "mocha";
 
 function getGrammarFilePath(): string {
@@ -10,9 +11,92 @@ function getGrammarFilePath(): string {
 const registry = new vsctm.Registry();
 const grammar = registry.loadGrammarFromPathSync(getGrammarFilePath());
 
+// Grammar constants
+const QuoteStringBeginScope = "punctuation.definition.string.begin.powerquery";
+const QuoteStringEndScope = "punctuation.definition.string.end.powerquery";
+const StringScope = "string.quoted.double.powerquery";
+
+class SingleLineTokenComparer {
+    public grammarTokens: vsctm.IToken[];
+    public parserTokens: readonly Token[]
+
+    constructor(query: string, normalize: boolean = true) {
+        let pqlex: Lexer.TLexer = Lexer.from(query);
+        pqlex = Lexer.remaining(pqlex);                
+        this.parserTokens = pqlex.tokens;        
+
+        // remove whitespace tokens from grammar result
+        let r = grammar.tokenizeLine(query, null);
+
+        this.grammarTokens = normalize ? SingleLineTokenComparer.NormalizeGrammarTokens(r.tokens) : r.tokens;
+
+        expect(this.parserTokens.length).greaterThan(0);
+        expect(this.grammarTokens.length).greaterThan(0);
+    }
+
+    public assertTokenCount() {
+        expect(this.parserTokens.length).equals(this.grammarTokens.length, "token counts are not equal");
+    }
+
+    public assertTokenOffsets() {
+        for (let i = 0; i < this.parserTokens.length; i++) {
+            const pt = this.parserTokens[i];
+            const gt = this.grammarTokens[i];
+
+            expect(pt.documentStartIndex).eq(gt.startIndex);
+            expect(pt.documentEndIndex).eq(gt.endIndex);
+        }
+    }
+
+    public static NormalizeGrammarTokens(tokens: vsctm.IToken[]): vsctm.IToken[] {
+        let result: vsctm.IToken[] = [];
+        
+        for (let i = 0; i < tokens.length; i++) {
+            const token = tokens[i];
+            
+            // PQ doesn't return tokens for whitespace. 
+            // Remove them from the grammar results.
+            if (token.scopes.length == 1) {
+                continue;
+            }
+
+            // PQ returns strings as a single token.
+            // Grammar returns separate tokens for punctuation.
+            // TODO: multiline string tokens?
+            if (token.scopes.includes(QuoteStringBeginScope)) {
+                var startIndex = token.startIndex;
+
+                // next token should be string
+                var stringToken = tokens[++i];
+                var scopes = stringToken.scopes;
+
+                // final token should be end quote
+                var endToken = tokens[++i];
+                var endIndex = endToken.endIndex;
+
+                // sanity
+                expect(scopes).contains(StringScope, "middle token should be a string");
+                expect(endToken.scopes).contains(QuoteStringEndScope, "third token should be end quote");
+
+                result.push({
+                    startIndex: startIndex,
+                    scopes: scopes,
+                    endIndex: endIndex
+                });
+
+                continue;
+            }
+
+            result.push(token);
+        }
+
+        return result;
+    }
+}
+
 describe("Basic grammar tests", () => {
     it("Grammar loaded", () => {
-        expect(grammar).is.not.null.and.is.not.undefined;
+        expect(grammar).to.exist;
     }),
 
     it("Tokens", () => {
@@ -32,4 +116,19 @@ in
             expect(r.tokens.length).to.be.greaterThan(0);
         }
     });
+});
+
+describe("Compare parser tokens", () => {
+    it("Logical", () => {
+        const query = "if true then true else false";
+        const r = new SingleLineTokenComparer(query);
+        r.assertTokenCount();
+        r.assertTokenOffsets();
+    }),    
+    it("Text", () => {
+        const query = "\"string one\" & \"string 2\"";
+        const r = new SingleLineTokenComparer(query);
+        r.assertTokenCount();
+        r.assertTokenOffsets();        
+    })
 });


### PR DESCRIPTION
Adds some basic tests that compare TextMate Grammar based tokenization to what comes from [powerquery-parser](https://github.com/Microsoft/powerquery-parser/). 

